### PR TITLE
Add Render deployment configuration for LlamaCloud MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# LlamaCloud MCP Server Configuration
+
+# Required: Your LlamaCloud API Key
+LLAMA_CLOUD_API_KEY=your-api-key-here
+
+# Required: Your LlamaCloud Organization ID
+ORG_ID=your-org-id-here
+
+# Optional: Project name or ID
+PROJECT_NAME=Default
+
+# Optional: Index configuration (name)
+INDEX_NAME=AI-Strategy-Studies
+
+# Optional: Index description
+INDEX_DESCRIPTION=Search and retrieve information from AI Strategy Studies
+
+# Optional: Transport type (stdio, sse, streamable-http)
+TRANSPORT=streamable-http
+
+# Optional: Port for web server (Render sets this automatically)
+PORT=8000

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,154 @@
+# Deploying LlamaCloud MCP Server to Render
+
+This guide walks you through deploying the LlamaCloud MCP server to Render.
+
+## Prerequisites
+
+1. A [Render account](https://render.com) (free tier available)
+2. A [LlamaCloud account](https://cloud.llamaindex.ai/)
+3. LlamaCloud API key
+4. Your LlamaCloud organization ID
+5. At least one configured index or extract agent in LlamaCloud
+
+## Current Configuration
+
+This deployment is configured with:
+- **Index Name**: AI-Strategy-Studies
+- **Project Name**: Default
+- **Organization ID**: 8d27cdab-b252-4a9b-a2c4-8eded34632a3
+- **Transport**: streamable-http (HTTP-based MCP server)
+
+## Deployment Steps
+
+### Option 1: Deploy via Render Dashboard
+
+1. **Create a New Web Service**
+   - Go to your Render dashboard
+   - Click "New +" → "Web Service"
+   - Connect your GitHub repository
+
+2. **Configure the Service**
+   - **Name**: `llamacloud-mcp-server` (or your preferred name)
+   - **Runtime**: Python 3
+   - **Build Command**: `pip install -e .`
+   - **Start Command**: `python start_server.py`
+
+3. **Set Environment Variables**
+   In the "Environment" section, add:
+   - `LLAMA_CLOUD_API_KEY`: Your LlamaCloud API key (⚠️ Keep this secret!)
+   - `INDEX_NAME`: `AI-Strategy-Studies`
+   - `INDEX_DESCRIPTION`: `Search and retrieve information from AI Strategy Studies`
+   - `PROJECT_NAME`: `Default`
+   - `ORG_ID`: `8d27cdab-b252-4a9b-a2c4-8eded34632a3`
+   - `TRANSPORT`: `streamable-http`
+
+4. **Deploy**
+   - Click "Create Web Service"
+   - Render will automatically build and deploy your service
+
+### Option 2: Deploy via render.yaml (Infrastructure as Code)
+
+1. **Push to GitHub**
+   ```bash
+   git add .
+   git commit -m "Add Render deployment configuration"
+   git push
+   ```
+
+2. **Create Blueprint in Render**
+   - Go to Render dashboard → "Blueprints"
+   - Click "New Blueprint Instance"
+   - Connect your repository
+   - Render will automatically detect `render.yaml`
+   - **Important**: Set the `LLAMA_CLOUD_API_KEY` as a secret environment variable in the Render dashboard (it's marked as `sync: false` for security)
+
+3. **Deploy**
+   - Review the configuration
+   - Click "Apply"
+
+## Post-Deployment
+
+### Access Your MCP Server
+
+Once deployed, your MCP server will be available at:
+```
+https://your-service-name.onrender.com
+```
+
+For streamable-http transport, the MCP endpoint will be:
+```
+https://your-service-name.onrender.com/mcp
+```
+
+### Testing the Server
+
+You can test if the server is running by checking the health endpoint or connecting an MCP client.
+
+### Using with Claude Desktop
+
+To use this MCP server with Claude Desktop, update your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "llamacloud-render": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/client",
+        "https://your-service-name.onrender.com/mcp"
+      ]
+    }
+  }
+}
+```
+
+## Monitoring and Logs
+
+- **Logs**: View real-time logs in the Render dashboard under your service
+- **Metrics**: Monitor CPU, memory usage, and request metrics
+- **Auto-Deploy**: Render automatically redeploys when you push to your main branch
+
+## Updating Configuration
+
+To update your index, extract agents, or other settings:
+
+1. Update the environment variables in the Render dashboard, OR
+2. Modify `render.yaml` and push changes to trigger a redeployment
+
+## Troubleshooting
+
+### Server won't start
+- Check that `LLAMA_CLOUD_API_KEY` is set correctly
+- Verify your organization ID and project name
+- Check the logs in Render dashboard
+
+### Port binding issues
+- The server automatically uses Render's `PORT` environment variable
+- Default port is 8000 if PORT is not set
+
+### Index not found
+- Verify the index name matches exactly (case-sensitive)
+- Check that the index exists in your LlamaCloud project
+- Verify organization ID and project ID are correct
+
+## Security Notes
+
+⚠️ **Never commit your API keys to the repository!**
+
+- Use Render's environment variables for secrets
+- The `LLAMA_CLOUD_API_KEY` in `render.yaml` is marked as `sync: false` to prevent accidental exposure
+- Always set sensitive values through the Render dashboard
+
+## Cost Considerations
+
+- Render offers a free tier with limitations
+- Consider upgrading to a paid plan for production use
+- Web services on free tier may spin down after inactivity
+
+## Next Steps
+
+- Add more indexes by updating the environment variables
+- Configure extract agents for document processing
+- Set up custom domains
+- Configure auto-scaling for production workloads

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  - type: web
+    name: llamacloud-mcp-server
+    runtime: python
+    plan: starter
+    buildCommand: pip install -e .
+    startCommand: python start_server.py
+    envVars:
+      - key: LLAMA_CLOUD_API_KEY
+        sync: false
+      - key: INDEX_NAME
+        value: AI-Strategy-Studies
+      - key: INDEX_DESCRIPTION
+        value: Search and retrieve information from AI Strategy Studies
+      - key: PROJECT_NAME
+        value: Default
+      - key: ORG_ID
+        value: 8d27cdab-b252-4a9b-a2c4-8eded34632a3
+      - key: TRANSPORT
+        value: streamable-http
+      - key: PYTHON_VERSION
+        value: 3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+llama-index-indices-managed-llama-cloud>=0.6.9
+mcp[cli]>=1.6.0
+python-dotenv>=1.1.0
+llama-index-tools-mcp>=0.1.0
+llama-cloud-services
+click

--- a/start_server.py
+++ b/start_server.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Startup script for deploying LlamaCloud MCP server on Render.
+This script reads configuration from environment variables and starts the MCP server.
+"""
+import os
+import sys
+from llamacloud_mcp.main import main
+
+def start():
+    """Start the MCP server with configuration from environment variables."""
+
+    # Get configuration from environment variables
+    api_key = os.getenv("LLAMA_CLOUD_API_KEY")
+    index_name = os.getenv("INDEX_NAME", "")
+    index_description = os.getenv("INDEX_DESCRIPTION", "Search index")
+    project_name = os.getenv("PROJECT_NAME")
+    org_id = os.getenv("ORG_ID")
+    transport = os.getenv("TRANSPORT", "streamable-http")
+    port = os.getenv("PORT", "8000")  # Render provides PORT env var
+
+    # Validate required variables
+    if not api_key:
+        print("ERROR: LLAMA_CLOUD_API_KEY environment variable is required", file=sys.stderr)
+        sys.exit(1)
+
+    if not org_id:
+        print("ERROR: ORG_ID environment variable is required", file=sys.stderr)
+        sys.exit(1)
+
+    # Set the API key in environment for the MCP server
+    os.environ["LLAMA_CLOUD_API_KEY"] = api_key
+
+    # Build the command line arguments
+    args = []
+
+    # Add index if configured
+    if index_name:
+        index_arg = f"{index_name}:{index_description}"
+        args.extend(["--index", index_arg])
+
+    # Add project name if configured
+    if project_name:
+        args.extend(["--project-id", project_name])
+
+    # Add org ID
+    args.extend(["--org-id", org_id])
+
+    # Add transport
+    args.extend(["--transport", transport])
+
+    # Add API key
+    args.extend(["--api-key", api_key])
+
+    print(f"Starting LlamaCloud MCP Server on port {port}...")
+    print(f"Transport: {transport}")
+    print(f"Index: {index_name}")
+    print(f"Organization ID: {org_id}")
+    print(f"Project: {project_name}")
+
+    # Set sys.argv to simulate command line arguments
+    sys.argv = ["llamacloud-mcp"] + args
+
+    # Run the main function
+    try:
+        main()
+    except Exception as e:
+        print(f"ERROR: Failed to start server: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    start()


### PR DESCRIPTION
This commit adds complete Render deployment support with:
- render.yaml: Infrastructure as code configuration for Render
- start_server.py: Startup script that reads config from environment variables
- requirements.txt: Python dependencies for easier deployment
- .env.example: Template for required environment variables
- DEPLOYMENT.md: Comprehensive deployment guide

Changes to main.py:
- Added --port option for web server deployments
- Automatic PORT environment variable detection for Render
- Support for sse and streamable-http transports with custom ports

Configuration includes:
- Index: AI-Strategy-Studies
- Project: Default
- Transport: streamable-http
- Auto-scaling support via Render